### PR TITLE
Adds Missing IPC Emotes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -151,7 +151,7 @@
     speechSounds: Borg
   - type: Vocal
     sounds:
-      Unsexed: UnisexSilicon
+      Unsexed: UnisexIPC # Box Change - starcup: silicon emotes
     wilhelmProbability: 0
   - type: DamagedSiliconAccent
   - type: UnblockableSpeech

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -45,7 +45,7 @@
     proto: robot
   - type: Vocal
     sounds:
-      Unsexed: UnisexSilicon
+      Unsexed: UnisexIPC #Box Change - starcup: silicon emotes
   - type: Emoting
   - type: ZombieImmune
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -34,9 +34,11 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+  #Start Box Change
+  #blacklist:
+    #tags:
+    #- SiliconEmotes
+  #End Box Change
   chatMessages: ["chat-emote-msg-laugh"]
   chatTriggers:
     - laugh
@@ -81,9 +83,10 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+  #Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
   chatMessages: ["chat-emote-msg-sigh"]
   chatTriggers:
     - sigh
@@ -98,9 +101,11 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+  # Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  #End Box Change
   chatMessages: ["chat-emote-msg-whistle"]
   chatTriggers:
     - whistle
@@ -115,9 +120,11 @@
   whitelist:
     components:
     - Vocal
-  blacklist:
-    tags:
-    - SiliconEmotes
+  # Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  # End Box Change
   chatMessages: ["chat-emote-msg-crying"]
   chatTriggers:
     - cry
@@ -298,9 +305,11 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+  # Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  # End Box Change
   chatMessages: ["chat-emote-msg-clap"]
   chatTriggers:
     - claps
@@ -315,9 +324,11 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+  # Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  # End Box Change
   chatMessages: [ "chat-emote-msg-clap-single" ]
   chatTriggers:
     - clap
@@ -334,9 +345,11 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+  # Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  # End Box Change
   chatMessages: ["chat-emote-msg-snap"]
   chatTriggers:
     - snap
@@ -385,9 +398,11 @@
   whitelist:
     components:
     - Hands
-  blacklist:
-    tags:
-    - SiliconEmotes
+  #Start Box Change
+  #blacklist:
+  #  tags:
+  #  - SiliconEmotes
+  #End Box Change
   chatMessages: ["chat-emote-msg-salute"]
   chatTriggers:
     - salute


### PR DESCRIPTION
## About the PR
As per: https://discord.com/channels/1406523997306359848/1409738859159490650
IPCs lacked basic emotes due to borg blacklisting.
This has since been rolled back to allow IPCS basic emotes.
This should in theory also allow borgs access to basic emotes. Honestly, I'm fine with this as a change, but if maintainers aren't happy with borgs being able to laugh then I can try and find a more elegant solution for this.
content ported from https://github.com/teamstarcup/starcup/pull/238. It was the most ideal solution. Props to them for it.

## Why / Balance
-IPC basic character expression to bring them up to parity with other species.
-Basic RP expression is important. These emotes are useful shorthands for emotions and should be supported with appropriate SFX.
-I think a janiborg laughing at me slipping on the wet floor is funny as fuck.

## Technical details
-Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml has been modified to replace the UnisexSilicon tag with UnisexIPC
-Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml same as above, tag replacement.
-Resources/Prototypes/Voice/speech_emotes.yml comments out blacklisting of emotes in here to allow IPCs and by  extension borgs to perform generic emotes.
## Media

https://github.com/user-attachments/assets/2be3e784-4617-4845-a02e-61a6ba3b89c6



## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Borgs now have emotes with custom SFX. They can laugh, cry, whistle, sigh, and more.
- fix: IPCs have emotes again, and can now laugh, cry, whistle, etc.

